### PR TITLE
Edition2024 + clippy fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,25 @@
 [package]
 name = "result-like"
 description = "Option/Result-like monad interface for your own enum"
+keywords = ["option", "result", "monad", "macro", "enum"]
+version.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+repository.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[workspace.package]
 version = "0.5.1"
 homepage = "https://github.com/youknowone/result-like"
 documentation = "http://docs.rs/result-like"
 repository = "https://github.com/youknowone/result-like"
-authors = ["Jeong YunWon <jeong+resultlike@youknowone.org>"]
+authors = ["Jeong, YunWon <jeong+resultlike@youknowone.org>"]
 edition = "2024"
+rust-version = "1.85.0"
 license = "BSD-2-Clause-Views"
-keywords = ["option", "result", "monad", "macro", "enum"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "result-like"
 description = "Option/Result-like monad interface for your own enum"
-version = "0.5.0"
+version = "0.5.1"
 homepage = "https://github.com/youknowone/result-like"
 documentation = "http://docs.rs/result-like"
 repository = "https://github.com/youknowone/result-like"
@@ -16,7 +16,7 @@ keywords = ["option", "result", "monad", "macro", "enum"]
 members = ["derive/"]
 
 [dependencies]
-result-like-derive = { version = "0.5.0", path = "derive/" }
+result-like-derive = { version = "0.5.1", path = "derive/" }
 
 [dev-dependencies]
 is-macro = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/youknowone/result-like"
 documentation = "http://docs.rs/result-like"
 repository = "https://github.com/youknowone/result-like"
 authors = ["Jeong YunWon <jeong+resultlike@youknowone.org>"]
-edition = "2021"
+edition = "2024"
 license = "BSD-2-Clause-Views"
 keywords = ["option", "result", "monad", "macro", "enum"]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Install: [https://crates.io/crates/result-like](https://crates.io/crates/result-like)
 
 Define your own Option-like and Result-like enum types.
-Avoid to reimplement everything of option and result for your own enums.
+Avoid reimplementing the entire APIs of option and result for your own enums.
 
 Option example
 ```rust

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "result-like-derive"
-version = "0.5.1"
-edition = "2024"
 description = "derive macros for result-like"
-repository = "https://github.com/youknowone/result-like"
-license = "BSD-2-Clause-Views"
+version.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+repository.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "result-like-derive"
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 description = "derive macros for result-like"
 repository = "https://github.com/youknowone/result-like"
 license = "BSD-2-Clause-Views"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "result-like-derive"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "derive macros for result-like"
 repository = "https://github.com/youknowone/result-like"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -2,11 +2,11 @@
 
 extern crate proc_macro;
 
-use pmutil::{smart_quote, Quote, ToTokensExt};
-use quote::{quote, ToTokens};
+use pmutil::{Quote, ToTokensExt, smart_quote};
+use quote::{ToTokens, quote};
 use syn::{
-    punctuated::Punctuated, token::Comma, Data, DataEnum, DeriveInput, Field, Generics, Ident,
-    WhereClause, WherePredicate,
+    Data, DataEnum, DeriveInput, Field, Generics, Ident, WhereClause, WherePredicate,
+    punctuated::Punctuated, token::Comma,
 };
 
 #[proc_macro_derive(BoolLike)]
@@ -272,7 +272,7 @@ impl LikeTrait for OptionLike {
                     #[inline]
                     pub fn as_option(&self) -> Option<&PrimaryValue> {
                         match self {
-                            Type::Primary(ref v) => Some(v),
+                            Type::Primary(v) => Some(v),
                             Type::Secondary => None,
                         }
                     }
@@ -280,7 +280,7 @@ impl LikeTrait for OptionLike {
                     #[inline]
                     pub fn as_option_mut(&mut self) -> Option<&mut PrimaryValue> {
                         match self {
-                            Type::Primary(ref mut v) => Some(v),
+                            Type::Primary(v) => Some(v),
                             Type::Secondary => None,
                         }
                     }
@@ -355,8 +355,8 @@ impl LikeTrait for OptionLike {
                             *self = Type::Primary(f());
                         }
 
-                        match *self {
-                            Type::Primary(ref mut v) => v,
+                        match self {
+                            Type::Primary(v) => v,
                             Type::Secondary => unsafe { core::hint::unreachable_unchecked() },
                         }
                     }
@@ -420,16 +420,16 @@ impl LikeTrait for OptionLike {
                     impl impl_generics Type ty_generics where_clause {
                         #[inline]
                         pub fn as_ref(&self) -> Type<&PrimaryValue> {
-                            match *self {
-                                Type::Primary(ref x) => Type::Primary(x),
+                            match self {
+                                Type::Primary(x) => Type::Primary(x),
                                 Type::Secondary => Type::Secondary,
                             }
                         }
 
                         #[inline]
                         pub fn as_mut(&mut self) -> Type<&mut PrimaryValue> {
-                            match *self {
-                                Type::Primary(ref mut x) => Type::Primary(x),
+                            match self {
+                                Type::Primary(x) => Type::Primary(x),
                                 Type::Secondary => Type::Secondary,
                             }
                         }
@@ -672,16 +672,16 @@ impl LikeTrait for ResultLike {
                     #[inline]
                     pub fn as_result(&self) -> Result<&T, &E> {
                         match self {
-                            Type::Primary(ref x) => Ok(x),
-                            Type::Secondary(ref x) => Err(x),
+                            Type::Primary(x) => Ok(x),
+                            Type::Secondary(x) => Err(x),
                         }
                     }
 
                     #[inline]
                     pub fn as_result_mut(&mut self) -> Result<&mut T, &mut E> {
                         match self {
-                            Type::Primary(ref mut x) => Ok(x),
-                            Type::Secondary(ref mut x) => Err(x),
+                            Type::Primary(x) => Ok(x),
+                            Type::Secondary(x) => Err(x),
                         }
                     }
 
@@ -928,16 +928,16 @@ impl LikeTrait for ResultLike {
                     #[inline]
                     pub fn as_ref(&self) -> Type<&T, &E> {
                         match self {
-                            Type::Primary(ref x) => Type::Primary(x),
-                            Type::Secondary(ref x) => Type::Secondary(x),
+                            Type::Primary(x) => Type::Primary(x),
+                            Type::Secondary(x) => Type::Secondary(x),
                         }
                     }
 
                     #[inline]
                     pub fn as_mut(&mut self) -> Type<&mut T, &mut E> {
                         match self {
-                            Type::Primary(ref mut x) => Type::Primary(x),
-                            Type::Secondary(ref mut x) => Type::Secondary(x),
+                            Type::Primary(x) => Type::Primary(x),
+                            Type::Secondary(x) => Type::Secondary(x),
                         }
                     }
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -762,12 +762,14 @@ impl LikeTrait for ResultLike {
                 _ => None,
             })
             .collect();
-        let primary_is_generic = primary_inner.iter().next().map_or(false, |f| {
-            param_symbols.contains(&f.ty.to_token_stream().to_string())
-        });
-        let secondary_is_generic = secondary_inner.iter().next().map_or(false, |f| {
-            param_symbols.contains(&f.ty.to_token_stream().to_string())
-        });
+        let primary_is_generic = primary_inner
+            .iter()
+            .next()
+            .is_some_and(|f| param_symbols.contains(&f.ty.to_token_stream().to_string()));
+        let secondary_is_generic = secondary_inner
+            .iter()
+            .next()
+            .is_some_and(|f| param_symbols.contains(&f.ty.to_token_stream().to_string()));
         let everything_is_generic = primary_is_generic && secondary_is_generic;
 
         // println!(

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -15,7 +15,7 @@ pub fn bool_like(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let data = match input.data {
         Data::Enum(ref data) => data,
-        _ => panic!("`OptionLike` can be applied only on enums"),
+        _ => panic!("`BoolLike` can be applied only on enums"),
     };
 
     expand(&input, BoolLike, data)
@@ -633,7 +633,8 @@ impl LikeTrait for ResultLike {
             ..
         } = args;
         let primary_inner = primary_inner.expect("primary_inner always exists for ResultLike");
-        let secondary_inner = secondary_inner.expect("primary_inner always exists for ResultLike");
+        let secondary_inner =
+            secondary_inner.expect("secondary_inner always exists for ResultLike");
         let (impl_generics, ty_generics, where_clause, where_predicates) = args.split_for_impl();
         let mut result_impl = Quote::new_call_site().quote_with(smart_quote!(
             Vars {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # OptionLike and ResultLike
 //!
 //! Define your own Option-like and Result-like enum types.
-//! Avoid to reimplement everything of [std::option::Option] and [std::result::Result] for your own enums.
+//! Avoid reimplementing the entire APIs of [std::option::Option] and [std::result::Result] for your own enums.
 //!
 //! Option example
 //! ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # OptionLike and ResultLike
 //!
 //! Define your own Option-like and Result-like enum types.
-//! Avoid to reimplement everything of [core::option::Option] and [core::result::Result] for your own enums.
+//! Avoid to reimplement everything of [std::option::Option] and [std::result::Result] for your own enums.
 //!
 //! Option example
 //! ```rust


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Version
  - Bumped package to 0.5.1.
- Chores
  - Updated Rust edition to 2024.
  - Bumped internal dependency (result-like-derive) to 0.5.1.
- Documentation
  - Clarified references to std Option and Result in module docs.
- Refactor/Style
  - Import reorganization and minor pattern simplifications with no behavior change.
- Compatibility
  - No changes to the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->